### PR TITLE
Fix paging half-heartedly

### DIFF
--- a/chief.py
+++ b/chief.py
@@ -125,8 +125,16 @@ def history(webapp):
         abort(404)
     else:
         app_settings = settings.WEBAPPS[webapp]
+
+    # TODO: This pages results poorly by pulling *all* the results
+    # back then slicing the returned list. It'd be better to pull just
+    # the results we were going to show.
+    page = request.GET.get('page', 0)
     results = get_history(webapp, app_settings)
+    results = results[page * 50:(page + 1) * 50]
+
     return render_template("history.html", app_name=webapp,
+                           page=page,
                            results=results)
 
 @app.route("/<webapp>/loadtest", methods=['GET', 'POST'])

--- a/templates/history.html
+++ b/templates/history.html
@@ -34,6 +34,15 @@
 </style>
 </head>
 <body>
+    <p>
+        {% if page > 0 %}
+            <a href="?page={{ page - 1 }}">Prev</a>
+        {% else %}
+            Prev
+        {% endif %}
+        | PAGE {{ page }} |
+        <a href="?page={{ page + 1 }}">Next</a>
+    </p>
     <table id="table">
         <thead>
             <tr>
@@ -56,4 +65,13 @@
             {% endfor %}
         </tbody>
     </table>
+    <p>
+        {% if page > 0 %}
+            <a href="?page={{ page - 1 }}">Prev</a>
+        {% else %}
+            Prev
+        {% endif %}
+        | PAGE {{ page }} |
+        <a href="?page={{ page + 1 }}">Next</a>
+    </p>
 </html>


### PR DESCRIPTION
This adds paging to the history/ section so we're not displaying _all_
the results.

The paging kind of sucks though since we have to pull back all the results
from redis since they're stored by keys and not by timestamp and we want
to sort them by timestamp before paging.

Two things to note:
1. If someone knows a good way of _not_ pulling everything back from redis, that'd be great.
2. I wasn't able to figure out how to test this--it seems like it requires a lot of setup that I can't easily do. I'll write up an issue for that.

r?
