### PR TITLE
PEP3333 compatibility, needed for gunicorn-0.17.2+

### DIFF
--- a/chief.py
+++ b/chief.py
@@ -76,7 +76,7 @@ def do_update(app_name, app_settings, webapp_ref, who):
 
         if getattr(settings, 'LOG_ROOT', None):
             yield prefix_notify('%s/%s/logs/%s\n' % (settings.LOG_ROOT,
-                                             app_name, log_name))
+                                                     app_name, log_name))
 
         pre_update_head = app_settings['pre_update'][:-1]
         pre_update_tail = [

--- a/chief.py
+++ b/chief.py
@@ -75,8 +75,8 @@ def do_update(app_name, app_settings, webapp_ref, who):
         yield prefix_notify('%s is pushing %s - %s\n' % (who, app_name, webapp_ref))
 
         if getattr(settings, 'LOG_ROOT', None):
-            yield prefix_notify('%s/%s/logs/%s' % (settings.LOG_ROOT,
-                                             app_name, log_name)) + '\n'
+            yield prefix_notify('%s/%s/logs/%s\n' % (settings.LOG_ROOT,
+                                             app_name, log_name))
 
         pre_update_head = app_settings['pre_update'][:-1]
         pre_update_tail = [
@@ -84,26 +84,26 @@ def do_update(app_name, app_settings, webapp_ref, who):
         run(pre_update_head + pre_update_tail, output)
 
         pub('PUSH')
-        yield prefix_notify('We have the new code!') + '\n'
-        yield prefix_notify('Running update tasks.') + '\n'
+        yield prefix_notify('We have the new code!\n')
+        yield prefix_notify('Running update tasks.\n')
 
         run(app_settings['update'], output)
 
         pub('UPDATE')
-        yield prefix_notify('Update tasks complete.') + '\n'
-        yield prefix_notify('Deploying to webheads.') + '\n'
+        yield prefix_notify('Update tasks complete.\n')
+        yield prefix_notify('Deploying to webheads.\n')
 
         run(app_settings['deploy'], output)
 
         pub('DONE')
         changelog(app_name)
         history('Success')
-        yield prefix_notify('Push complete!') + '\n'
+        yield prefix_notify('Push complete!\n')
 
     except:
         pub('FAIL')
         history('Fail')
-        yield prefix_notify('Something terrible has happened!') + '\n'
+        yield prefix_notify('Something terrible has happened!\n')
         raise
 
 def changelog(app_name):

--- a/chief.py
+++ b/chief.py
@@ -33,7 +33,7 @@ def fix_settings(app_settings):
 def notify(msg):
     for notifier in getattr(settings, 'NOTIFIERS', []):
         notifier(msg)
-    return msg
+    return bytes(msg)
 
 
 def do_update(app_name, app_settings, webapp_ref, who):
@@ -48,7 +48,7 @@ def do_update(app_name, app_settings, webapp_ref, who):
 
     def prefix_notify(msg):
         notify('%s:%s %s' % (app_name, webapp_ref[:12], msg))
-        return msg
+        return bytes(msg)
 
     def run(task, output):
         subprocess.check_call(task,

--- a/chief.py
+++ b/chief.py
@@ -72,8 +72,7 @@ def do_update(app_name, app_settings, webapp_ref, who):
         output = open(log_file, 'a')
 
         pub('BEGIN')
-        notify('%s is pushing %s - %s' % (who, app_name, webapp_ref))
-        yield '%s is pushing %s - %s\n' % (who, app_name, webapp_ref)
+        yield prefix_notify('%s is pushing %s - %s\n' % (who, app_name, webapp_ref))
 
         if getattr(settings, 'LOG_ROOT', None):
             yield prefix_notify('%s/%s/logs/%s' % (settings.LOG_ROOT,


### PR DESCRIPTION
gunicorn-0.17.2 and above requires strings sent to the browser to be bytes rather than "strings". Simple conversion. This isn't an issue with plain strings that use no variables (or only locally-defined ones), but becomes a problem when using variables either passed in or from the environment. This occurs only once, but for future-proofing and uniformity I'm just wrapping it all the time.

This also changes the layout of calls to prefix_notify() slightly, again for uniformity... and to make sure it gets wrapped in "bytes()" properly also.